### PR TITLE
fix: 显式设置 CI 的 Node 版本

### DIFF
--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -10,6 +10,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Add `actions/setup-node@v5` to `.github/workflows/ci-check.yaml` before Bun setup, and read the Node version from `.nvmrc`. This makes CI use the same Node 24 runtime as the project instead of relying on the runner default. It keeps Astro 6 checks, lint, and build on a supported Node version. Local validation: `bun run check`, `bun run lint`, and `bun run build`.